### PR TITLE
refactor(send): specify complete HOST instead of just the IP to be able to use ngrok

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,19 @@
-# ws-midi
+<h1>ws-midi</h1>
 > Send MIDI using WebSocket communication
 
 <p align="center"><img alt="Animated image of two terminals demonstrating the usage of ws-midi" src="https://github.com/vcync/ws-midi/raw/main/images/ws-midi.gif" width="100%" /></p>
+
+---
+
+<!-- TOC -->
+
+- [Usage](#usage)
+  - [Usage with ngrok](#usage-with-ngrok)
+- [Requirements](#requirements)
+
+<!-- /TOC -->
+
+---
 
 ## Usage
 
@@ -12,6 +24,19 @@
 * Start the receiver first
 * When it asks for an IP, that's your WAN IP (search "what's my IP" on Google)
 * The receiver will have a virtual MIDI device called "ws-midi" to use in MIDI-capable apps
+
+
+### Usage with ngrok
+
+To get the connection working over network where we don't have access to the network-settings, we can use a service like ngrok to tunnel the connection:
+
+* Setup account at ngrok
+* Start ws-midi receiver on the remote host that should receive the signal
+* Start ngrok with `ngrok http 5006` (the port used by ws-midi) on the remote host
+* Start ws-midi send on the local host that should send the signal to the remote host
+  * Use the host url as provided by ngrok in this format: `wss://<ngrok-url>` (we don't need the port as this goes over HTTPS)
+
+This should then pipe the signal from a local host to the remote host and you should see the MIDI signals arriving there. 
 
 ## Requirements
 

--- a/send.js
+++ b/send.js
@@ -2,7 +2,7 @@ const term = require('terminal-kit').terminal;
 const midi = require('midi');
 const WebSocket = require('ws');
 const { VIRTUAL_MIDI_DEVICE_NAME, PORT } = require('./constants.js');
-let ip;
+let host;
 
 module.exports = () => {
   // Set up a new input.
@@ -37,20 +37,20 @@ module.exports = () => {
     }
   }
 
-  term.cyan(`please enter the IP of the recipient\n`);
+  term.cyan(`please enter the HOST of the recipient in the format ws://host[:port] or wss://host[:port]\n`);
 
   term.inputField((error, response) => {
     term.clear();
-    ip = response;
+    host = response;
 
-    term.cyan(`opening websocket connection to ${ip}:${PORT}\n`);
-    const ws = new WebSocket(`ws://${ip}:${PORT}`);
+    term.cyan(`opening websocket connection to ${host}\n`);
+    const ws = new WebSocket(`${host}`);
 
     ws.on('open', () => {
       term.clear();
-      term.cyan(`opened websocket connection to ${ip}:${PORT}\n\n`);
+      term.cyan(`opened websocket connection to ${host}\n\n`);
 
-      term.cyan(`please pick a midi input device to send to ${ip}:${PORT}\n`);
+      term.cyan(`please pick a midi input device to send to ${host}\n`);
 
       term.singleColumnMenu(inputDeviceNames, {
         cancelable: true,
@@ -66,7 +66,7 @@ module.exports = () => {
 
         const midiInputDeviceId = response.selectedIndex;
 
-        term.cyan(`opened websocket connection to ${ip}:${PORT}\n\n`);
+        term.cyan(`opened websocket connection to ${host}\n\n`);
 
         term.cyan(`please pick a midi output device to route locally`);
 


### PR DESCRIPTION
* Setup account at ngrok
* Start ws-midi receiver
* Start ngrok with `ngrok http 5006` (the port used by ws-midi)
* Start ws-midi send
  * Use the host url as provided by ngrok in this format: `wss://<ngrok-url>` (we don't need the port as this goes over HTTPS)
